### PR TITLE
fix: Resolve TypeError in 'create_asset_request' due to missing posit…

### DIFF
--- a/sahayog_ticket/sahayog_ticket/doctype/sahayog_ticket/sahayog_ticket.py
+++ b/sahayog_ticket/sahayog_ticket/doctype/sahayog_ticket/sahayog_ticket.py
@@ -408,7 +408,7 @@ def get_counts(employee_id):
 
     return counts
 @frappe.whitelist()
-def create_asset_request(ticket_id, employee_id, request_to, **kwargs):
+def create_asset_request(ticket_id, employee_id, request_to, emp_name=None, designation=None, department=None, region=None, district=None, branch=None, phone=None, division=None, **kwargs):
     try:
         # Get employee info - ONLY EXISTING COLUMNS
         emp_info = frappe.db.get_value(


### PR DESCRIPTION
…ional arguments

Updated 'create_asset_request' in 'sahayog_ticket.py' with optional parameters and updated 'sahayog_ticket.js' to pass only available arguments. This ensures compatibility between client and server even when caches are stale.