### PR TITLE
fix: strip +91 prefix before contact_number validation

### DIFF
--- a/sahayog_ticket/sahayog_ticket/doctype/sahayog_ticket/sahayog_ticket.js
+++ b/sahayog_ticket/sahayog_ticket/doctype/sahayog_ticket/sahayog_ticket.js
@@ -2143,12 +2143,12 @@ frappe.ui.form.on("Ticket Item", {
             "customer_name",
             r.message.customer_name,
           );
-          frappe.model.set_value(
-            cdt,
-            cdn,
-            "contact_number",
-            r.message.contact_number,
-          );
+          let contact_number = r.message.contact_number || "";
+          // Strip +91 prefix if present
+          if (contact_number.startsWith("+91")) {
+            contact_number = contact_number.substring(3);
+          }
+          frappe.model.set_value(cdt, cdn, "contact_number", contact_number);
           frappe.model.set_value(
             cdt,
             cdn,

--- a/sahayog_ticket/sahayog_ticket/doctype/sahayog_ticket/sahayog_ticket.py
+++ b/sahayog_ticket/sahayog_ticket/doctype/sahayog_ticket/sahayog_ticket.py
@@ -234,7 +234,10 @@ class SahayogTicket(Document):
 
             # Validate new_contact_number (if present)
             if row.new_contact_number:
-                if not re.match(mobile_pattern, row.new_contact_number):
+                new_contact = row.new_contact_number
+                if new_contact.startswith("+91"):
+                    new_contact = new_contact[3:]
+                if not re.match(mobile_pattern, new_contact):
                     frappe.throw(
                         _("Row #{0}: Enter valid 10-digit Indian Mobile Number").format(row.idx)
                     )
@@ -262,7 +265,10 @@ class SahayogTicket(Document):
 
             # Validate contact_number (if present)
             if row.contact_number:
-                if not re.match(mobile_pattern, row.contact_number):
+                contact = row.contact_number
+                if contact.startswith("+91"):
+                    contact = contact[3:]
+                if not re.match(mobile_pattern, contact):
                     frappe.throw(
                         _("Row #{0}: Contact Number must be a valid 10-digit Indian Mobile Number").format(row.idx)
                     )

--- a/sahayog_ticket/sahayog_ticket/doctype/ticket_item/ticket_item.py
+++ b/sahayog_ticket/sahayog_ticket/doctype/ticket_item/ticket_item.py
@@ -13,7 +13,10 @@ class TicketItem(Document):
 					frappe._("Account Number must be a valid 15-digit number")
 				)
 		if self.contact_number:
-			if not re.match(r"^[6-9]\d{9}$", str(self.contact_number)):
+			contact_number = str(self.contact_number)
+			if contact_number.startswith("+91"):
+				contact_number = contact_number[3:]
+			if not re.match(r"^[6-9]\d{9}$", contact_number):
 				frappe.throw(
 					frappe._("Contact Number must be a valid 10-digit Indian Mobile Number")
 				)


### PR DESCRIPTION
- Strip +91 from contact_number/new_contact_number before applying 10-digit Indian mobile regex validation in both ticket_item.py and sahayog_ticket.py
- Strip +91 prefix client-side when fetching account details via get_account_details API